### PR TITLE
Dockerized build of `mctrace`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,110 @@
+FROM ubuntu:22.04 AS base
+
+# Variables to be updated
+ARG GHCUP_BIN_DIR=/root/.ghcup/bin
+ARG GHCUP_DWN_URL=https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup
+ARG GHC_VERSION=8.10.7
+
+
+# Environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PATH=${PATH}:${GHCUP_BIN_DIR}
+
+
+# Install basic stuff
+RUN \
+  apt-get update && \
+  apt-get upgrade -y
+
+RUN \
+  apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    gnupg2
+
+RUN \
+  apt-get install -y \
+    g++ \
+    gcc \
+    git \
+    libc-dev \
+    make
+
+# And stuff specific for mctrace
+RUN \
+  apt-get install -y \
+    libgmp-dev \
+    zlib1g-dev \
+    llvm-12-dev \
+    llvm-12-runtime
+
+
+# Install Ghcup and then haskell and cabal
+RUN \
+  mkdir -p ${GHCUP_BIN_DIR}
+
+
+RUN \
+	curl -sSL ${GHCUP_DWN_URL} > ${GHCUP_BIN_DIR}/ghcup && \
+	chmod +x ${GHCUP_BIN_DIR}/ghcup
+
+RUN \
+  ghcup upgrade && \
+  ghcup install cabal && \
+  ghcup install ghc ${GHC_VERSION} -p 'x86_64-deb10-linux' && \
+  ghcup set ghc ${GHC_VERSION}
+
+RUN cabal update
+
+
+# Get MCTrace
+RUN git clone https://github.com/GaloisInc/mctrace.git /root/mctrace
+
+# We need to tweak the git config so that submodule clones work over https
+# before submodule fetch
+WORKDIR /root/mctrace
+RUN git config --global url."https://github.com/".insteadOf "git@github.com:"
+RUN git config --global url."https://".insteadOf "git://"
+RUN git submodule update --init
+
+# Build mctrace
+RUN ln -s cabal.project.dist cabal.project
+RUN ln -s cabal.project.freeze.ghc-${GHC_VERSION} cabal.project.freeze
+RUN cabal configure pkg:mctrace
+RUN cabal build pkg:mctrace
+
+
+# Final stage where we build a minimal image
+FROM ubuntu:22.04
+
+# Environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV SOURCE_MCTRACE_ROOT=/root/mctrace
+ENV TARGET_MCTRACE_ROOT=/mctrace-bin
+
+# Install packages
+RUN \
+  apt-get update && \
+  apt-get upgrade -y
+
+RUN apt-get install -y musl-tools make
+
+
+# Copy the minimal amount of files we need to get this running
+COPY --from=base \
+    ${SOURCE_MCTRACE_ROOT}/dist-newstyle/build/x86_64-linux/ghc-8.10.7/mctrace-0.1.0.0/x/mctrace/build/mctrace/mctrace \
+    ${TARGET_MCTRACE_ROOT}/mctrace
+
+COPY --from=base /lib/x86_64-linux-gnu/libLLVM-12.so.1 /lib/x86_64-linux-gnu/libLLVM-12.so.1
+COPY --from=base /lib/x86_64-linux-gnu/libedit.so.2 /lib/x86_64-linux-gnu/libedit.so.2
+COPY --from=base /lib/x86_64-linux-gnu/libxml2.so.2 /lib/x86_64-linux-gnu/libxml2.so.2
+COPY --from=base /lib/x86_64-linux-gnu/libbsd.so.0 /lib/x86_64-linux-gnu/libbsd.so.0
+COPY --from=base /lib/x86_64-linux-gnu/libicuuc.so.70 /lib/x86_64-linux-gnu/libicuuc.so.70
+COPY --from=base /lib/x86_64-linux-gnu/libmd.so.0 /lib/x86_64-linux-gnu/libmd.so.0
+COPY --from=base /lib/x86_64-linux-gnu/libicudata.so.70 /lib/x86_64-linux-gnu/libicudata.so.70
+
+ENV PATH=${PATH}:${TARGET_MCTRACE_ROOT}
+
+
+

--- a/README.org
+++ b/README.org
@@ -56,7 +56,11 @@ MCTrace compiles DTrace probe scripts into native code using a compiler backend 
 
 The storage backend for telemetry data will ultimately be configurable to support a wide range of systems.  At the moment, telemetry is stored in a memory mapped region backed by a file on disk.  The region is allocated at program startup.  Each probe modifies values in that region.  When the program exits, the telemetry information persists in the file.  Users can then collect this telemetry information for offline analysis.  When instrumenting a binary with a set of probes, ~mctrace~ can emit a mapping file that describes the location of each probe variable in the collected telemetry.
 
-* Build Instructions
+* Building MCTrace
+
+MCTrace binaries can be built in two ways: either locally, given a Haskell build environment and an LLVM installation, or via a Dockerfile. Instructions for both are in the following sections.
+
+** Local Build Instructions
 
 Assuming you have a Haskell compiler installed (GHC >= 8.6 and < 9), the following instructions will build the MCTrace tool:
 
@@ -69,7 +73,55 @@ cabal build pkg:mctrace
 
 #+END_SRC
 
-Note that ~mctrace~ currently requires LLVM 9 to be installed and accessible for code generation.
+Note that ~mctrace~ currently requires LLVM 12 to be installed and accessible for code generation.
+
+** Docker-based Build Instructions and Usage
+
+To build the docker image, execute the following from the root of the repository:
+#+BEGIN_SRC bash
+docker build -t mctrace - < Dockerfile
+#+END_SRC
+
+This will build a self-contained image that contains MCTrace, its dependencies and associated tools. To run the container, execute something like:
+
+#+BEGIN_SRC bash
+docker run -it -v $PWD:/mctrace -w /mctrace mctrace
+#+END_SRC
+
+Note that this mounts the current directory as ~/mctrace~ in the container and leaves you in a bash shell in that directory.
+The ~mctrace~ binary as well as ~musl-gcc~ (used to build ~musl~-based statically-linked binaries) should be accessible from this shell.
+
+** Testing the Tools
+
+To test the tools, first build a test binary:
+#+BEGIN_SRC bash
+cd mctrace/tests/full/ && make
+#+END_SRC
+
+An example probe is available in =mctrace/test/eval=. To instrument this binary with the probe, from the same directory, execute:
+#+BEGIN_SRC bash
+mctrace instrument \
+    --binary=read-syscall --output=/tmp/read-syscall.instrumented \
+    --var-mapping=/tmp/read-syscall.mapping.json --persistence-file=/tmp/telemetry.bin \
+    --script=../eval/single-add-probe.d
+#+END_SRC
+
+This produces the instrumented binary =/tmp/read-syscall.instrumented= as well as a mapping file =/tmp/read-syscall.mapping.json=, which we require
+later to extract telemetry information. Then run the instrumented binary:
+#+BEGIN_SRC bash
+/tmp/read-syscall.instrumented
+#+END_SRC
+
+This creates the file =/tmp/telemetry.bin= that contains the telemetry information in binary format. To interpret these results, execute:
+#+BEGIN_SRC bash
+mctrace extract \
+    --var-mapping=/tmp/read-syscall.mapping.json \
+    --persistence-file=/tmp/telemetry.bin
+#+END_SRC
+
+This should display the set of variables defined in the probes and their values.
+
+Other binaries can be instrumented, run and interpreted in a similar fashion.
 
 * Roadmap
 


### PR DESCRIPTION
The Dockerfile builds and installs `mctrace` and also includes an installation of `musl-gcc`. The resulting image should allow for building binaries, instrumenting them and extracting telemetry data after runs.